### PR TITLE
chore: update repository template to c7a2e1f9

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,0 +1,1 @@
+*       @ory/maintainers

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,15 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+assignees:
+  - ory/maintainers
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+addAssignees: author


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/c7a2e1f9ac8e52f80278670c47aa6a562872ebc5.